### PR TITLE
ci: 文档检查步骤添加 --no-deps 以忽略依赖项文档构建

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           args: --all-targets
 
       - name: Test Documentation
-        run: cargo doc --document-private-items
+        run: cargo doc --no-deps --document-private-items
 
       - name: Check Code Format
         run: cargo fmt --check


### PR DESCRIPTION
明显不需要构建依赖项的文档来做检查。

参考 reqwest 的配置
https://github.com/seanmonstar/reqwest/blob/3d56bd66f5ac77d6a1a75329a943aed9927f5acf/.github/workflows/ci.yml#L283-L286