### PR TITLE
refactor!: 重构错误类型

### DIFF
--- a/docs/code_fmt.md
+++ b/docs/code_fmt.md
@@ -15,8 +15,8 @@
 - `src/error.rs` 中提供了一些错误转换的辅助函数：
   - `.network_err()`：网络请求错误。可以作用在 `reqwest` 库中可能返回 `reqwest::Error` 的地方，将其转为 `NetworkError`
   - `.unexpected_err()`：难以归类或理论上不应失败的错误。可以作用在任意的错误类型上，将其转为 `Unexpected`
-  - `.parse_err(data)?` / `.parse_err_with_reason(data, reason)?`：解析失败的错误。可以作用在任意的错误类型上，将其转为 `ParseError`
-  - 有时解析失败可能并非抛出了什么错误导致，而是某些条件不满足，对于这种情况我们可以手动调用函数 `parse_err` / `parse_err_with_reason` 来直接构造解析错误
+  - `.parse_err(data)`：解析失败的错误。可以作用在任意的错误类型上，将其转为 `ParseError`
+  - 有时解析失败可能并非抛出了什么错误导致，而是某些条件不满足，对于这种情况我们可以手动调用函数 `parse_err` 来直接构造解析错误
 - 域内特有的错误放在该系统的 `error.rs`（如 `TokenExpired`）。某个接口的特定错误放在功能子模块内（如 `LoginIssue`、`AccountIssue`）
 - 没有特定错误时，`E` 使用 `std::convert::Infallible`
 - 不应该使用 `unwrap`，已经配置 `clippy` 规则进行禁止。会 panic 的地方（比如 `assert` 和 `expect`），仅用于全局单例初始化（如正则表达式构建）或是文档明确声明会 panic 的前置条件。如果根据代码逻辑，某个代码写了看似会 panic 的地方实际不会执行，那么就无需写到函数的文档注释。

--- a/src/ai/login.rs
+++ b/src/ai/login.rs
@@ -180,7 +180,7 @@ impl AiToken {
         let oauth_json: Value = serde_json::from_str(&oauth_text).parse_err(&oauth_text)?;
         let bearer_token = oauth_json["data"]["token"]
             .as_str()
-            .ok_or_else(|| parse_err(&oauth_text))?;
+            .ok_or_else(|| parse_err("找不到 bearer token", &oauth_text))?;
 
         let mut headers = HeaderMap::new();
         headers.insert(

--- a/src/ai/token/parse.rs
+++ b/src/ai/token/parse.rs
@@ -21,7 +21,7 @@ pub fn token_key(json_str: &str) -> Result<String, crate::Error<Infallible>> {
     let json: Value = serde_json::from_str(json_str).parse_err(json_str)?;
     let key = json["data"]["key"]
         .as_str()
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析 token key", json_str))?;
     Ok(key.to_string())
 }
 
@@ -32,7 +32,7 @@ pub fn check_action_success(json_str: &str) -> Result<bool, crate::Error<Infalli
     let json: Value = serde_json::from_str(json_str).parse_err(json_str)?;
     let success = json["success"]
         .as_bool()
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析操作是否成功", json_str))?;
     Ok(success)
 }
 

--- a/src/ai/user_info/parse.rs
+++ b/src/ai/user_info/parse.rs
@@ -7,7 +7,7 @@ pub fn remaining_quota(json_str: &str) -> Result<usize, crate::Error<Infallible>
     let res: Value = serde_json::from_str(json_str).parse_err(json_str)?;
     let total_granted = res["data"]["total_granted"]
         .as_u64()
-        .ok_or_else(|| parse_err(json_str))? as usize;
+        .ok_or_else(|| parse_err("无法解析总配额", json_str))? as usize;
     Ok(total_granted)
 }
 

--- a/src/ca/grade_rank/parse.rs
+++ b/src/ca/grade_rank/parse.rs
@@ -9,22 +9,18 @@ use std::{convert::Infallible, sync::LazyLock};
 pub fn preview_file_name(json_str: &str) -> Result<String, crate::Error<Infallible>> {
     let json: Value = serde_json::from_str(json_str).parse_err(json_str)?;
     if json.get("code").and_then(|v| v.as_u64()) != Some(200) {
-        return Err(parse_err(json_str));
+        return Err(parse_err("无法解析响应代码", json_str));
     }
     json.get("message")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
-        .ok_or_else(|| parse_err(json_str))
+        .ok_or_else(|| parse_err("无法解析文件名", json_str))
 }
 
 /// `pdf_bytes` 可接收来自 [super::fetch::file] 的返回值
 pub fn rank(pdf_bytes: Bytes) -> Result<Rank, crate::Error<Infallible>> {
-    let text_extracted = pdf_extract::extract_text_from_mem(&pdf_bytes).map_err(|e| {
-        parse_err(&format!(
-            "failed to extract PDF text ({} bytes): {e}",
-            pdf_bytes.len()
-        ))
-    })?;
+    let text_extracted = pdf_extract::extract_text_from_mem(&pdf_bytes)
+        .parse_err(&format!("{} bytes", pdf_bytes.len()))?;
     rank_with_pdf_text(&text_extracted)
 }
 
@@ -39,9 +35,12 @@ fn rank_with_pdf_text(pdf_text: &str) -> Result<Rank, crate::Error<Infallible>> 
 
     let caps = REGEX
         .captures(pdf_text)
-        .ok_or(parse_err(pdf_text))?
+        .ok_or(parse_err("正则匹配失败", pdf_text))?
         .iter()
-        .map(|c| c.map(|v| v.as_str().to_string()).ok_or(parse_err(pdf_text)))
+        .map(|c| {
+            c.map(|v| v.as_str().to_string())
+                .ok_or(parse_err("无法解析 PDF 文本", pdf_text))
+        })
         .collect::<Result<Vec<_>, _>>()?;
     // 12 个捕获组，caps[0] 是完整匹配，共 13 个
     let [
@@ -58,7 +57,9 @@ fn rank_with_pdf_text(pdf_text: &str) -> Result<Rank, crate::Error<Infallible>> 
         all_weighted,
         core_weighted_rank,
         must_weighted,
-    ] = caps.try_into().map_err(|_| parse_err(pdf_text))?;
+    ] = caps
+        .try_into()
+        .map_err(|_| parse_err("无法解析 PDF 文本", pdf_text))?;
     let res = Rank {
         all_gpa,
         all_gpa_rank,

--- a/src/ca/login.rs
+++ b/src/ca/login.rs
@@ -1,8 +1,6 @@
 use crate::cas;
 use crate::cas::login::CasToken;
-use crate::error::{
-    CheckStatusCodeErr, MapNetworkErr, MapParseErr, MapUnexpectedErr, parse_err_with_reason,
-};
+use crate::error::{CheckStatusCodeErr, MapNetworkErr, MapParseErr, MapUnexpectedErr, parse_err};
 use crate::utils::client;
 use reqwest::header::HeaderMap;
 use serde_json::Value;
@@ -65,7 +63,7 @@ impl CaToken {
         }
         let token = json["result"]["token"]
             .as_str()
-            .ok_or_else(|| parse_err_with_reason(&json_str, "Ca 系统返回的 token 字段不存在"))?;
+            .ok_or_else(|| parse_err("找不到 token", &json_str))?;
         let cookie = format!("X-Access-Token={token}");
         let mut headers = HeaderMap::new();
         headers.insert("X-Access-Token", token.parse().parse_err(token)?);

--- a/src/cas/login.rs
+++ b/src/cas/login.rs
@@ -151,11 +151,11 @@ impl CasToken {
         let pubkey: Value = serde_json::from_str(&pubkey_str).parse_err(&pubkey_str)?;
         let modulus = pubkey["modulus"]
             .as_str()
-            .ok_or_else(|| parse_err(&pubkey_str))?
+            .ok_or_else(|| parse_err("无法解析modulus", &pubkey_str))?
             .to_string();
         let exponent = pubkey["exponent"]
             .as_str()
-            .ok_or_else(|| parse_err(&pubkey_str))?
+            .ok_or_else(|| parse_err("无法解析exponent", &pubkey_str))?
             .to_string();
         // 加密密码
         let encrypted_password = utils::rsa_encrypt(password, &exponent, &modulus)

--- a/src/cas/tfa.rs
+++ b/src/cas/tfa.rs
@@ -1,6 +1,6 @@
 use crate::{
     cas::login::{AccountIssue, CasToken},
-    error::{CheckStatusCodeErr, MapNetworkErr, MapUnexpectedErr, parse_err_with_reason},
+    error::{CheckStatusCodeErr, MapNetworkErr, MapUnexpectedErr, parse_err},
     utils::{client, obs, request::cookie_parser},
 };
 use regex::RegexBuilder;
@@ -67,13 +67,13 @@ impl TFAToken {
             .captures(html)
             .and_then(|cap| cap.get(1))
             .map(|m| m.as_str())
-            .ok_or_else(|| parse_err_with_reason(html, "没有找到execution"))?
+            .ok_or_else(|| parse_err("没有找到execution", html))?
             .to_string();
         let phone = regex_phone
             .captures(html)
             .and_then(|cap| cap.get(1))
             .map(|m| m.as_str())
-            .ok_or_else(|| parse_err_with_reason(html, "没有找到绑定手机号"))?
+            .ok_or_else(|| parse_err("没有找到绑定手机号", html))?
             .to_string();
         Ok(Self {
             phone,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use crate::utils::obs;
 use std::error::Error as StdError;
 
-#[expect(clippy::enum_variant_names)]
 #[derive(thiserror::Error, Debug)]
 pub enum Error<E: StdError> {
     /// 意料之外的错误
@@ -16,53 +15,50 @@ pub enum Error<E: StdError> {
     /// - [reqwest::Response::text] 失败
     /// - 在非解析数据部分，期望应该解析到一些数据但是没有解析到，
     ///   比如没有在响应头的 Location 找到 `ticket_url`，
-    ///   这个算作 [Error::Unexpected] 而不算 [Error::ParseError]
-    #[error(
-        "出现了意料之外的错误，详情信息请使用调试打印，\
-        如果问题存在可靠的复现方式，请向开发者反馈"
-    )]
-    Unexpected {
-        #[source]
-        error: Box<dyn StdError + Send + Sync>,
-        file: String,
-        line: u32,
-        column: u32,
-    },
+    ///   这个算作 [Error::Unexpected] 而不算 [Error::Parse]
+    #[error(transparent)]
+    Unexpected(UnexpectedError),
     /// 底层请求错误
     ///
     /// 网络问题，请求超时等来自网络环境的问题，建议稍后重试
-    #[error(transparent)]
-    NetworkError(reqwest::Error),
+    #[error("网络错误: {0}")]
+    Network(#[source] reqwest::Error),
     /// 数据解析错误
     ///
     /// 该错误意味着遇到了意料之外的数据格式，当前的库暂时无法解析。
     /// 请向开发者反馈以改进本项目
-    #[error("数据解析错误")]
-    ParseError {
-        error: Option<Box<dyn StdError + Send + Sync>>,
-        reason: Option<String>,
-        data: String,
-    },
+    #[error(transparent)]
+    Parse(ParseError),
     /// 其他错误
     ///
     /// 具体错误请见调用函数的文档
     #[error(transparent)]
-    Other(#[from] E),
+    Other(E),
 }
 
-pub fn parse_err<T: StdError>(data: &str) -> Error<T> {
-    Error::ParseError {
-        error: None,
-        reason: None,
-        data: data.to_string(),
+/// 见 [Error::Unexpected]
+#[derive(thiserror::Error, Debug)]
+#[error("意料之外的错误：{error}")]
+pub struct UnexpectedError {
+    #[source]
+    error: Box<dyn StdError + Send + Sync>,
+    file: String,
+    line: u32,
+    column: u32,
+}
+
+impl UnexpectedError {
+    /// 抛出错误的代码文件路径
+    pub fn file(&self) -> &str {
+        &self.file
     }
-}
-
-pub fn parse_err_with_reason<T: StdError>(data: &str, reason: &str) -> Error<T> {
-    Error::ParseError {
-        error: None,
-        reason: Some(reason.to_string()),
-        data: data.to_string(),
+    /// 抛出错误的代码行号
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+    /// 抛出错误的代码列号
+    pub fn column(&self) -> u32 {
+        self.column
     }
 }
 
@@ -70,6 +66,7 @@ pub trait MapUnexpectedErr<T, E>
 where
     E: StdError,
 {
+    /// 转换某一[Result]中的错误为[Error::Unexpected]
     fn unexpected_err(self) -> Result<T, Error<E>>;
 }
 
@@ -78,15 +75,16 @@ where
     E0: Into<Box<dyn StdError + Send + Sync>>,
     E: StdError,
 {
-    /// 转换某一[Result]中的错误为[Error::Unexpected]
     #[track_caller]
     fn unexpected_err(self) -> Result<T, Error<E>> {
         let loc = std::panic::Location::caller();
-        self.map_err(|e| Error::Unexpected {
-            error: e.into(),
-            file: loc.file().to_string(),
-            line: loc.line(),
-            column: loc.column(),
+        self.map_err(|e| {
+            Error::Unexpected(UnexpectedError {
+                error: e.into(),
+                file: loc.file().to_string(),
+                line: loc.line(),
+                column: loc.column(),
+            })
         })
     }
 }
@@ -95,49 +93,85 @@ pub trait MapNetworkErr<T, E>
 where
     E: StdError,
 {
+    /// 将[Result]中的错误转换为[Error::Network]
     fn network_err(self) -> Result<T, Error<E>>;
-}
-
-impl<T, E> MapNetworkErr<T, E> for Result<T, reqwest::Error>
-where
-    E: StdError,
-{
-    /// 将[reqwest::Error]转换为[Error::NetworkError]
-    fn network_err(self) -> Result<T, Error<E>> {
-        self.map_err(Error::NetworkError)
-    }
 }
 
 impl<T, E> MapNetworkErr<T, E> for Result<T, reqwest_middleware::Error>
 where
     E: StdError,
 {
-    /// 将 [reqwest_middleware::Error] 转换为 [crate::Error]
+    /// 将 [reqwest_middleware::Error] 转换为 [Error]
     ///
-    /// - `Reqwest(reqwest::Error)` 变体映射为 [Error::NetworkError]
+    /// - `Reqwest(reqwest::Error)` 变体映射为 [Error::Network]
     /// - `Middleware(...)` 变体映射为 [Error::Unexpected]
     ///   （middleware 自身出错的概率极低）
     #[track_caller]
     fn network_err(self) -> Result<T, Error<E>> {
         let loc = std::panic::Location::caller();
         self.map_err(|e| match e {
-            reqwest_middleware::Error::Reqwest(r) => Error::NetworkError(r),
-            reqwest_middleware::Error::Middleware(m) => Error::Unexpected {
+            reqwest_middleware::Error::Reqwest(r) => Error::Network(r),
+            reqwest_middleware::Error::Middleware(m) => Error::Unexpected(UnexpectedError {
                 error: m.into(),
                 file: loc.file().to_string(),
                 line: loc.line(),
                 column: loc.column(),
-            },
+            }),
         })
     }
+}
+
+/// 见 [Error::Parse]
+#[derive(thiserror::Error, Debug)]
+#[error("数据解析错误：{error}")]
+pub struct ParseError {
+    #[source]
+    error: Box<dyn StdError + Send + Sync>,
+    file: String,
+    line: u32,
+    column: u32,
+    data: String,
+}
+
+impl ParseError {
+    /// 抛出错误的代码文件路径
+    pub fn file(&self) -> &str {
+        &self.file
+    }
+    /// 抛出错误的代码行号
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+    /// 抛出错误的代码列号
+    pub fn column(&self) -> u32 {
+        self.column
+    }
+    /// 解析失败的数据
+    pub fn data(&self) -> &str {
+        &self.data
+    }
+}
+
+#[track_caller]
+pub fn parse_err<E: StdError>(reason: &str, data: &str) -> Error<E> {
+    let loc = std::panic::Location::caller();
+    Error::Parse(ParseError {
+        error: reason.into(),
+        file: loc.file().to_string(),
+        line: loc.line(),
+        column: loc.column(),
+        data: data.to_string(),
+    })
 }
 
 pub trait MapParseErr<T, E>
 where
     E: StdError,
 {
+    /// 将[Result]中的错误转换为[Error::Parse]
+    ///
+    /// `data` 为解析失败的数据
     fn parse_err(self, data: &str) -> Result<T, Error<E>>;
-    fn parse_err_with_reason(self, data: &str, reason: &str) -> Result<T, Error<E>>;
 }
 
 impl<T, E, E0> MapParseErr<T, E> for Result<T, E0>
@@ -145,18 +179,17 @@ where
     E0: Into<Box<dyn StdError + Send + Sync>>,
     E: StdError,
 {
+    #[track_caller]
     fn parse_err(self, data: &str) -> Result<T, Error<E>> {
-        self.map_err(|e| Error::ParseError {
-            error: Some(e.into()),
-            reason: None,
-            data: data.to_string(),
-        })
-    }
-    fn parse_err_with_reason(self, data: &str, reason: &str) -> Result<T, Error<E>> {
-        self.map_err(|e| Error::ParseError {
-            error: Some(e.into()),
-            reason: Some(reason.to_string()),
-            data: data.to_string(),
+        let loc = std::panic::Location::caller();
+        self.map_err(|e| {
+            Error::Parse(ParseError {
+                error: e.into(),
+                file: loc.file().to_string(),
+                line: loc.line(),
+                column: loc.column(),
+                data: data.to_string(),
+            })
         })
     }
 }
@@ -186,16 +219,12 @@ impl CheckStatusCodeErr for reqwest::Response {
             let status = self.status();
             if status.is_client_error() || status.is_server_error() {
                 obs::error!(status = %status, body = %self.text().await.unwrap_or_default(), "status code error");
-                Err(Error::Unexpected {
-                    // 可能 std::io::Error 语义上不太合适，不过懒得改了先这这样
-                    error: Box::new(std::io::Error::other(format!(
-                        "status code error: {}",
-                        status
-                    ))),
+                Err(Error::Unexpected(UnexpectedError {
+                    error: format!("status code error: {status}").into(),
                     file,
                     line,
                     column,
-                })
+                }))
             } else {
                 Ok(self)
             }

--- a/src/gym/parse.rs
+++ b/src/gym/parse.rs
@@ -19,16 +19,16 @@ pub fn gym_response(json_str: &str) -> Result<Value, crate::Error<TokenExpired>>
     if json
         .get("info")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| parse_err(json_str))?
+        .ok_or_else(|| parse_err("无法解析响应", json_str))?
         .contains("登录失效")
     {
         return Err(crate::Error::Other(TokenExpired));
     }
     if json.get("status").and_then(|v| v.as_i64()) != Some(1) {
-        return Err(parse_err(json_str));
+        return Err(parse_err("响应状态错误", json_str));
     }
     let Some(data) = json.get("data") else {
-        return Err(parse_err(json_str));
+        return Err(parse_err("无法解析响应数据", json_str));
     };
     Ok(data.clone())
 }

--- a/src/hdjw/class_table/parse.rs
+++ b/src/hdjw/class_table/parse.rs
@@ -1,6 +1,6 @@
 use super::{Course, CourseSchedule, ExtraCourse};
 use crate::{
-    error::{MapParseErr, parse_err, parse_err_with_reason},
+    error::{MapParseErr, parse_err},
     hdjw::error::TokenExpired,
 };
 use regex::Regex;
@@ -84,10 +84,7 @@ fn day_to_u8(c: char) -> Result<u8, crate::Error<TokenExpired>> {
         '五' => Ok(5),
         '六' => Ok(6),
         '日' | '七' => Ok(7),
-        _ => Err(parse_err_with_reason(
-            &format!("未知的星期字符: {c}"),
-            "上课时间: day",
-        )),
+        _ => Err(parse_err("未知的星期字符", &format!("{c}"))),
     }
 }
 
@@ -99,11 +96,9 @@ fn extract_time_list(s: &str, context: &str) -> Result<HashSet<u8>, crate::Error
         let time_l = parts
             .first()
             .and_then(|v| v.parse::<u8>().ok())
-            .ok_or(parse_err_with_reason(context, "上课时间: time"))?;
+            .ok_or(parse_err("找不到上课节次", context))?;
         let time_r = match parts.get(1) {
-            Some(v) => v
-                .parse::<u8>()
-                .parse_err_with_reason(context, "上课时间: time")?,
+            Some(v) => v.parse::<u8>().parse_err(context)?,
             None => time_l,
         };
         time_set.extend(time_l..=time_r);
@@ -119,11 +114,9 @@ fn extract_week_list(s: &str, context: &str) -> Result<HashSet<u8>, crate::Error
         let week_l = parts
             .first()
             .and_then(|v| v.parse::<u8>().ok())
-            .ok_or(parse_err_with_reason(context, "上课时间: week"))?;
+            .ok_or(parse_err("找不到上课周次", context))?;
         let week_r = match parts.get(1) {
-            Some(v) => v
-                .parse::<u8>()
-                .parse_err_with_reason(context, "上课时间: week")?,
+            Some(v) => v.parse::<u8>().parse_err(context)?,
             None => week_l,
         };
         week_set.extend(week_l..=week_r);
@@ -142,25 +135,27 @@ fn course_schedule(raw: &RawCourseInfo) -> Result<Vec<CourseSchedule>, crate::Er
     for (i, time) in detail_times.into_iter().enumerate() {
         let caps = SKTIME_RE
             .captures(time)
-            .ok_or(parse_err_with_reason(&raw.sktime, "上课时间: day"))?;
-        let day = day_to_u8(caps.get(1).and_then(|v| v.as_str().chars().next()).ok_or(
-            parse_err_with_reason(&raw.sktime, "上课时间: day: 没有匹配到星期字符"),
-        )?)?;
+            .ok_or(parse_err("无法解析上课时间", &raw.sktime))?;
+        let day = day_to_u8(
+            caps.get(1)
+                .and_then(|v| v.as_str().chars().next())
+                .ok_or(parse_err("找不到上课星期", &raw.sktime))?,
+        )?;
         let time_list = extract_time_list(
             caps.get(2)
-                .ok_or(parse_err_with_reason(&raw.sktime, "上课时间: time"))?
+                .ok_or(parse_err("找不到上课节次", &raw.sktime))?
                 .as_str(),
             &raw.sktime,
         )?;
         let week_list = extract_week_list(
             caps.get(3)
-                .ok_or(parse_err_with_reason(&raw.sktime, "上课时间: week"))?
+                .ok_or(parse_err("找不到上课周次", &raw.sktime))?
                 .as_str(),
             &raw.sktime,
         )?;
         let place = places
             .get(i)
-            .ok_or(parse_err_with_reason(&raw.skddmc, "上课地点"))?;
+            .ok_or(parse_err("找不到上课地点", &raw.skddmc))?;
         week_list.iter().for_each(|&week| {
             schedule
                 .entry((week, day, place.to_string()))
@@ -183,7 +178,7 @@ fn course_schedule(raw: &RawCourseInfo) -> Result<Vec<CourseSchedule>, crate::Er
 pub fn class_table(json_str: &str) -> Result<Vec<Course>, crate::Error<TokenExpired>> {
     let json = crate::hdjw::parse::hdjw_response(json_str)?;
     let raw_data = match json.get("count").and_then(|c| c.as_u64()) {
-        None => return Err(parse_err(json_str)),
+        None => return Err(parse_err("无法解析课程表数据", json_str)),
         Some(0) => return Ok(vec![]), // 有可能 count 是 0 但是不带 data 字段
         Some(_) => serde_json::from_value::<Vec<RawCourseInfo>>(json["data"].clone())
             .parse_err(json_str)?,
@@ -214,7 +209,7 @@ pub fn class_table(json_str: &str) -> Result<Vec<Course>, crate::Error<TokenExpi
 pub fn class_table_extra(json_str: &str) -> Result<Vec<ExtraCourse>, crate::Error<TokenExpired>> {
     let json = crate::hdjw::parse::hdjw_response(json_str)?;
     let raw_data = match json.get("count").and_then(|c| c.as_u64()) {
-        None => return Err(parse_err(json_str)),
+        None => return Err(parse_err("无法解析无课程表数据", json_str)),
         Some(0) => return Ok(vec![]), // 有可能 count 是 0 但是不带 data 字段
         Some(_) => serde_json::from_value::<Vec<RawExtraCourseInfo>>(json["data"].clone())
             .parse_err(json_str)?,

--- a/src/hdjw/empty_classroom/parse.rs
+++ b/src/hdjw/empty_classroom/parse.rs
@@ -1,8 +1,5 @@
 use super::EmptyClassroom;
-use crate::{
-    error::{parse_err, parse_err_with_reason},
-    hdjw::error::TokenExpired,
-};
+use crate::{error::parse_err, hdjw::error::TokenExpired};
 
 /// # Arguments
 ///
@@ -17,19 +14,18 @@ pub fn empty_classroom(
         .as_array()
         .and_then(|v| v.get(4))
         .and_then(|v| v.as_array())
-        .ok_or(parse_err(&raw_data.to_string()))?;
+        .ok_or(parse_err("无法解析空教室信息", &raw_data.to_string()))?;
     let mut res = Vec::new();
     for item in data {
-        let item = item.as_array().ok_or(parse_err(&item.to_string()))?;
+        let item = item
+            .as_array()
+            .ok_or(parse_err("无法解析空教室信息", &item.to_string()))?;
         let mut is_free = true;
         // 需要每一节课均为空才会被认为是空教室
         for i in 1..=time.len() {
             if !item
                 .get(i)
-                .ok_or(parse_err_with_reason(
-                    &format!("{:?}", item),
-                    "空教室占用情况",
-                ))?
+                .ok_or(parse_err("无法解析空教室占用情况", &format!("{:?}", item)))?
                 .is_null()
             {
                 is_free = false;
@@ -45,21 +41,21 @@ pub fn empty_classroom(
             item.get(2 + time.len()).and_then(|v| v.as_str()),
             item.get(3 + time.len()).and_then(|v| v.as_str()),
         ) else {
-            return Err(parse_err_with_reason(&format!("{:?}", item), "空教室信息"));
+            return Err(parse_err("解析空教室具体信息失败", &format!("{:?}", item)));
         };
 
         if seat_count_str.len() < 3
             || !seat_count_str.starts_with('(')
             || !seat_count_str.ends_with(')')
         {
-            return Err(parse_err_with_reason(seat_count_str, "座位数"));
+            return Err(parse_err("无法解析座位数", seat_count_str));
         }
         let [Ok(seat_count), Ok(exam_seat_count)] = seat_count_str[1..seat_count_str.len() - 1]
             .split('/')
             .map(|x| x.parse::<u32>())
             .collect::<Vec<_>>()[..]
         else {
-            return Err(parse_err_with_reason(seat_count_str, "座位数"));
+            return Err(parse_err("无法解析座位数", seat_count_str));
         };
         res.push(EmptyClassroom {
             room_name: room_name.to_string(),

--- a/src/hdjw/exam_schedule/parse.rs
+++ b/src/hdjw/exam_schedule/parse.rs
@@ -33,7 +33,7 @@ pub fn exam_schedule(json_str: &str) -> Result<Vec<ExamSchedule>, crate::Error<T
         let (date, time) = match item.kssj {
             Some(kssj) => {
                 let [date, time] = kssj.split(' ').collect::<Vec<_>>()[..] else {
-                    return Err(parse_err(&kssj));
+                    return Err(parse_err("无法解析考试时间", &kssj));
                 };
                 let date = NaiveDate::parse_from_str(date, "%Y-%m-%d").parse_err(date)?;
                 (Some(date), Some(time.to_string()))

--- a/src/hdjw/grade/parse.rs
+++ b/src/hdjw/grade/parse.rs
@@ -85,7 +85,10 @@ pub fn grade_detail(html: &str) -> Result<Vec<GradeDetailItem>, crate::Error<Tok
     let json = crate::hdjw::parse::hdjw_response(html)?;
     // 不要直接 to_string()，
     // 否则会把整段 HTML 当作 JSON 字符串再序列化，导致内部引号变成 \"
-    let raw_data = json.as_str().ok_or_else(|| parse_err(html))?.to_string();
+    let raw_data = json
+        .as_str()
+        .ok_or_else(|| parse_err("无法解析成绩详情", html))?
+        .to_string();
     static REGEX: LazyLock<Regex> = LazyLock::new(|| {
         RegexBuilder::new(r"let\sarr\s=\s(.*);.*window.initQzTable\(\{.*cols:\s\[(.*)\].*\}\);")
             .dot_matches_new_line(true)
@@ -94,14 +97,16 @@ pub fn grade_detail(html: &str) -> Result<Vec<GradeDetailItem>, crate::Error<Tok
     });
     let caps = REGEX
         .captures(&raw_data)
-        .ok_or_else(|| parse_err(&raw_data))?
+        .ok_or_else(|| parse_err("正则匹配失败", &raw_data))?
         .iter()
         .map(|c| {
             c.map(|v| v.as_str().to_string())
-                .ok_or_else(|| parse_err(&raw_data))
+                .ok_or_else(|| parse_err("无法解析成绩详情", &raw_data))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let [_, data, map] = caps.try_into().map_err(|_| parse_err(&raw_data))?;
+    let [_, data, map] = caps
+        .try_into()
+        .map_err(|_| parse_err("匹配数量错误", &raw_data))?;
     let data = serde_json::from_str::<Vec<Value>>(&data).parse_err(&raw_data)?;
     let data = data
         .first()
@@ -113,12 +118,12 @@ pub fn grade_detail(html: &str) -> Result<Vec<GradeDetailItem>, crate::Error<Tok
                         .as_str()
                         .map(|s| s.to_string())
                         .or(value.as_number().map(|num| num.to_string()))
-                        .ok_or_else(|| parse_err(&raw_data))
+                        .ok_or_else(|| parse_err("解析分数失败", &raw_data))
                         .map(|ok_value| (key, ok_value))
                 })
                 .collect::<Result<HashMap<_, _>, _>>()
         })
-        .ok_or_else(|| parse_err(&raw_data))??;
+        .ok_or_else(|| parse_err("无法解析成绩详情", &raw_data))??;
     // map 是 js obj 格式，不是标准 json，我们需要进行一些处理
     let map = map
         .replace("//表头", "")
@@ -136,21 +141,21 @@ pub fn grade_detail(html: &str) -> Result<Vec<GradeDetailItem>, crate::Error<Tok
                 .map(|item| {
                     let key = item.get("field").and_then(|f| f.as_str());
                     key.zip(item.get("title").and_then(|f| f.as_str()))
-                        .ok_or_else(|| parse_err(&raw_data))
+                        .ok_or_else(|| parse_err("无法解析成绩组成", &raw_data))
                 })
                 .collect::<Result<HashMap<_, _>, _>>()
         })
-        .ok_or_else(|| parse_err(&raw_data))??;
+        .ok_or_else(|| parse_err("无法解析成绩组成", &raw_data))??;
     let res = data
         .iter()
         .filter(|(k, _)| k.ends_with("bl"))
         .map(|(k, v)| {
             let score = data
                 .get(&k.trim_end_matches("bl").to_string())
-                .ok_or_else(|| parse_err(&raw_data))?;
+                .ok_or_else(|| parse_err("找不到成绩组成分数", &raw_data))?;
             let name = map
                 .get(k.trim_end_matches("bl"))
-                .ok_or_else(|| parse_err(&raw_data))?;
+                .ok_or_else(|| parse_err("找不到成绩组成名称", &raw_data))?;
             let percentage = v;
             Ok::<_, crate::Error<TokenExpired>>(GradeDetailItem {
                 score: score.clone(),

--- a/src/hdjw/parse.rs
+++ b/src/hdjw/parse.rs
@@ -1,4 +1,4 @@
-use crate::{error::parse_err, hdjw::error::TokenExpired};
+use crate::{error::MapParseErr, hdjw::error::TokenExpired};
 use serde_json::Value;
 
 /// 解析教务系统响应，同时会检查 cookie 是否过期，如果过期则返回 [TokenExpired] 错误
@@ -9,10 +9,7 @@ pub fn hdjw_response(body_str: &str) -> Result<Value, crate::Error<TokenExpired>
     if body_str.contains("window.initQzTable") {
         return Ok(Value::String(body_str.to_string()));
     }
-    let json = match serde_json::from_str::<Value>(body_str) {
-        Ok(json) => json,
-        Err(_) => return Err(parse_err(body_str)),
-    };
+    let json = serde_json::from_str::<Value>(body_str).parse_err(body_str)?;
     // 典型的 cookie 失效时的 response body：
     // {"flag1":2,"msgContent":"è¯·å…ˆç™»å½•ç³»ç»Ÿ"}
     // 这里只判断 flag1 字段，因为 msgContent 是乱码，不好说

--- a/src/hdjw/rank/parse.rs
+++ b/src/hdjw/rank/parse.rs
@@ -13,21 +13,24 @@ fn parse_number(value: &Value) -> Option<String> {
 
 fn rank_detail(value: &Value) -> Result<RankDetail, crate::Error<TokenExpired>> {
     Ok(RankDetail {
-        arithmetic: parse_number(&value["avgzcj"]).ok_or(parse_err(&value.to_string()))?,
+        arithmetic: parse_number(&value["avgzcj"])
+            .ok_or(parse_err("无法解析算数平均成绩", &value.to_string()))?,
         arithmetic_rank: value["avgzcjpm"]
             .as_str()
             .map(|s| s.to_string())
-            .ok_or(parse_err(&value.to_string()))?,
-        weighted: parse_number(&value["pjxfj"]).ok_or(parse_err(&value.to_string()))?,
+            .ok_or(parse_err("无法解析算数平均排名", &value.to_string()))?,
+        weighted: parse_number(&value["pjxfj"])
+            .ok_or(parse_err("无法解析加权平均成绩", &value.to_string()))?,
         weighted_rank: value["pjxfjpm"]
             .as_str()
             .map(|s| s.to_string())
-            .ok_or(parse_err(&value.to_string()))?,
-        gpa: parse_number(&value["pjxfjd"]).ok_or(parse_err(&value.to_string()))?,
+            .ok_or(parse_err("无法解析加权平均排名", &value.to_string()))?,
+        gpa: parse_number(&value["pjxfjd"])
+            .ok_or(parse_err("无法解析加权平均绩点", &value.to_string()))?,
         gpa_rank: value["pjxfjdpm"]
             .as_str()
             .map(|s| s.to_string())
-            .ok_or(parse_err(&value.to_string()))?,
+            .ok_or(parse_err("无法解析加权平均绩点排名", &value.to_string()))?,
     })
 }
 
@@ -36,7 +39,7 @@ pub fn rank(json_str: &str) -> Result<Rank, crate::Error<TokenExpired>> {
     let json = crate::hdjw::parse::hdjw_response(json_str)?;
     let raw_data = match json.get("data") {
         Some(data @ Value::Object(_)) => data.clone(),
-        _ => return Err(parse_err(json_str)),
+        _ => return Err(parse_err("无法解析教务系统排名数据", json_str)),
     };
     Ok(Rank {
         all: raw_data.get("allPm").map(rank_detail).transpose()?,

--- a/src/lab/course/parse.rs
+++ b/src/lab/course/parse.rs
@@ -26,7 +26,7 @@ pub fn course_list(json_str: &str) -> Result<Vec<Course>, crate::Error<Infallibl
         .get("rows")
         .map(|v| serde_json::from_value::<Vec<RawCourse>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析大物实验课程列表", json_str))?;
     let mut res = Vec::with_capacity(raw_data.len());
     for item in raw_data {
         res.push(Course {

--- a/src/lab/grade/parse.rs
+++ b/src/lab/grade/parse.rs
@@ -47,7 +47,7 @@ fn parse_lab_grade(json_str: &str) -> Result<Vec<RawLabGrade>, crate::Error<Infa
         .get("rows")
         .map(|v| serde_json::from_value::<Vec<RawLabGrade>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))
+        .ok_or_else(|| parse_err("无法解析大物实验成绩", json_str))
 }
 
 fn parse_lab_grade_detail(
@@ -59,7 +59,7 @@ fn parse_lab_grade_detail(
         .and_then(|v| v.get("Lablist"))
         .map(|v| serde_json::from_value::<Vec<RawLabGradeDetail>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))
+        .ok_or_else(|| parse_err("无法解析大物实验成绩详情", json_str))
 }
 
 fn parse_lab_grade_structure(
@@ -70,7 +70,7 @@ fn parse_lab_grade_structure(
         .get("Data")
         .map(|v| serde_json::from_value::<Vec<RawLabGradeStructure>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))
+        .ok_or_else(|| parse_err("无法解析大物实验成绩组成", json_str))
 }
 
 /// # Arguments
@@ -144,7 +144,7 @@ pub fn virtual_lab_grade(json_str: &str) -> Result<Vec<VirtualLabGrade>, crate::
         .get("rows")
         .map(|v| serde_json::from_value::<Vec<RawVirtualLabGrade>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析虚拟实验成绩", json_str))?;
     let mut res = Vec::new();
     for item in raw_data.into_iter() {
         let tmp = VirtualLabGrade {

--- a/src/lab/login/mod.rs
+++ b/src/lab/login/mod.rs
@@ -98,7 +98,7 @@ impl LabToken {
             let data_str = res.text().await.unexpected_err()?;
             let data: Value = serde_json::from_str(&data_str).parse_err(&data_str)?;
             let Some(code) = data["RTNCode"].as_i64() else {
-                return Err(parse_err(&data_str));
+                return Err(parse_err("无法解析登录结果", &data_str));
             };
             if code == -2 {
                 // 需要验证码

--- a/src/lab/schedule/parse.rs
+++ b/src/lab/schedule/parse.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{MapParseErr, parse_err, parse_err_with_reason},
+    error::{MapParseErr, parse_err},
     lab::schedule::LabSchedule,
 };
 use chrono::{NaiveDate, NaiveTime};
@@ -41,7 +41,7 @@ pub fn lab_schedule(json_str: &str) -> Result<Vec<LabSchedule>, crate::Error<Inf
         .get("rows")
         .map(|v| serde_json::from_value::<Vec<RawLabSchedule>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析大物实验安排", json_str))?;
     let mut res = Vec::with_capacity(raw_data.len());
     for item in raw_data {
         let day = match item.WeekName.as_str() {
@@ -53,22 +53,19 @@ pub fn lab_schedule(json_str: &str) -> Result<Vec<LabSchedule>, crate::Error<Inf
             "星期六" => 6,
             "星期日" => 7,
             _ => {
-                return Err(parse_err_with_reason(&item.WeekName, "day"));
+                return Err(parse_err("无法解析上课星期", &item.WeekName));
             }
         };
-        let week = item
-            .Weeks
-            .parse::<u8>()
-            .parse_err_with_reason(&item.Weeks, "week")?;
+        let week = item.Weeks.parse::<u8>().parse_err(&item.Weeks)?;
         let date = item
             .ClassDate
             .split(' ')
             .next()
-            .map(|v| NaiveDate::parse_from_str(v, "%Y/%m/%d").parse_err_with_reason(v, "date"))
+            .map(|v| NaiveDate::parse_from_str(v, "%Y/%m/%d").parse_err(v))
             .transpose()?
-            .ok_or_else(|| parse_err_with_reason(&item.ClassDate, "date"))?;
-        let time = NaiveTime::parse_from_str(&item.StartTime, "%H:%M")
-            .parse_err_with_reason(&item.StartTime, "time")?;
+            .ok_or_else(|| parse_err("无法解析上课日期", &item.ClassDate))?;
+        let time =
+            NaiveTime::parse_from_str(&item.StartTime, "%H:%M").parse_err(&item.StartTime)?;
         let tmp = LabSchedule {
             seat: item.SeatNo,
             name: item.LabName,

--- a/src/lab/semester/parse.rs
+++ b/src/lab/semester/parse.rs
@@ -21,10 +21,10 @@ pub fn semester(json_str: &str) -> Result<Vec<Semester>, crate::Error<Infallible
             .split(|c| ['-', '_', ' '].contains(&c))
             .collect::<Vec<&str>>()[..]
         else {
-            return Err(parse_err(&item.text));
+            return Err(parse_err("无法解析学期", &item.text));
         };
         let (Ok(xn), Ok(xq)) = (xn_str.parse::<u16>(), xq_str.parse::<u8>()) else {
-            return Err(parse_err(&item.text));
+            return Err(parse_err("无法解析学期", &item.text));
         };
         res.push(Semester {
             xn,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,18 +17,20 @@
 
 pub mod ai;
 pub mod ca;
-mod error;
+pub mod cas;
 pub mod gym;
 pub mod hdjw;
 pub mod lab;
 pub mod netflow;
 pub mod pt;
-mod utils;
 pub mod wxpay;
 pub mod xgxt;
 pub mod yjsxt;
-pub use error::Error;
-pub mod cas;
+
+mod error;
+pub use error::{Error, ParseError, UnexpectedError};
+
+mod utils;
 
 #[cfg(test)]
 pub mod test;

--- a/src/netflow/detail/parse.rs
+++ b/src/netflow/detail/parse.rs
@@ -30,7 +30,7 @@ pub fn detail(json_str: &str) -> Result<Detail, crate::Error<Infallible>> {
         .get("data")
         .map(|v| serde_json::from_value::<RawDetail>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析校园网流量详情", json_str))?;
     let res = Detail {
         total: raw_data.AllTotal,
         upload: raw_data.AllUpload,

--- a/src/netflow/order/parse.rs
+++ b/src/netflow/order/parse.rs
@@ -23,7 +23,7 @@ pub fn order(json_str: &str) -> Result<Vec<OrderItem>, crate::Error<Infallible>>
         .get("data")
         .map(|v| serde_json::from_value::<Vec<RawOrderItem>>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析校园网订单", json_str))?;
     raw_data
         .into_iter()
         .map(|item| {

--- a/src/netflow/pay_info/parse.rs
+++ b/src/netflow/pay_info/parse.rs
@@ -16,7 +16,7 @@ pub fn overdue_payment(json_str: &str) -> Result<f64, crate::Error<Infallible>> 
         .get("data")
         .map(|v| serde_json::from_value::<RawPayInfo>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析欠费信息", json_str))?;
     Ok(raw_data.Total)
 }
 

--- a/src/netflow/this_month/parse.rs
+++ b/src/netflow/this_month/parse.rs
@@ -33,7 +33,7 @@ pub fn this_month_info(json_str: &str) -> Result<ThisMonthInfo, crate::Error<Inf
         .get("data")
         .map(|v| serde_json::from_value::<RawThisMonthInfo>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析本月网络流量信息", json_str))?;
     let mut res = ThisMonthInfo {
         total_usage: raw_data.allTraffic,
         upload_usage: raw_data.uploadTraffic,

--- a/src/netflow/user_info/parse.rs
+++ b/src/netflow/user_info/parse.rs
@@ -11,7 +11,7 @@ pub fn unlock_status(json_str: &str) -> Result<UnlockStatus, crate::Error<Infall
         .get("data")
         .and_then(|d| d.get("IsLocked"))
         .and_then(|v| v.as_i64())
-        .ok_or(parse_err(json_str))?;
+        .ok_or(parse_err("无法解析解锁状态", json_str))?;
     match is_locked {
         0 => Ok(UnlockStatus::Unlocked),
         1 => Ok(UnlockStatus::Locked),

--- a/src/pt/card/parse.rs
+++ b/src/pt/card/parse.rs
@@ -38,7 +38,7 @@ pub fn csrf_token(json_str: &str) -> Result<String, crate::Error<Infallible>> {
         .parse_err(json_str)?
         .get("data")
         .and_then(|v| v.as_str().map(|s| s.to_string()))
-        .ok_or_else(|| parse_err(json_str))
+        .ok_or_else(|| parse_err("找不到 CSRF 令牌", json_str))
 }
 
 /// `json_str` 为 [super::fetch::card_info] 的返回数据
@@ -48,7 +48,7 @@ pub fn card_info(json_str: &str) -> Result<CardInfo, crate::Error<Infallible>> {
         .get("data")
         .map(|v| serde_json::from_value::<RawCardInfo>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析校园卡信息", json_str))?;
 
     let raw_balance = raw_data
         .balance
@@ -68,25 +68,22 @@ pub fn card_history(json_str: &str) -> Result<CardHistory, crate::Error<Infallib
         .get("data")
         .map(|v| serde_json::from_value::<RawCardHistory>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析校园卡历史记录", json_str))?;
     let raw_items = raw_data.webTrjnDTO.unwrap_or_default();
     let mut items = Vec::with_capacity(raw_items.len());
     for item in raw_items {
         let date_time = NaiveDateTime::parse_from_str(&item.effectdate, "%Y/%m/%d %H:%M:%S")
-            .parse_err_with_reason(&item.effectdate, "date_time")?;
+            .parse_err(&item.effectdate)?;
         let journal_time = NaiveDateTime::parse_from_str(&item.jndatetime, "%Y/%m/%d %H:%M:%S")
-            .parse_err_with_reason(&item.jndatetime, "journal_time")?;
+            .parse_err(&item.jndatetime)?;
         let now_balance = item
             .nowAmt
             .trim()
             // 可能会有 1,359.30 这种情况
             .replace([',', ' '], "")
             .parse::<f64>()
-            .parse_err_with_reason(&item.nowAmt, "now_balance")?;
-        let amount = item
-            .fTranAmt
-            .parse::<f64>()
-            .parse_err_with_reason(&item.fTranAmt, "amount")?;
+            .parse_err(&item.nowAmt)?;
+        let amount = item.fTranAmt.parse::<f64>().parse_err(&item.fTranAmt)?;
         items.push(CardHistoryItem {
             date_time,
             journal_time,

--- a/src/pt/email/parse.rs
+++ b/src/pt/email/parse.rs
@@ -16,7 +16,7 @@ pub fn email_unread_count(json_str: &str) -> Result<Option<u32>, crate::Error<In
         .get("data")
         .map(|v| serde_json::from_value::<RawUnreadEmail>(v.clone()).parse_err(json_str))
         .transpose()?
-        .ok_or_else(|| parse_err(json_str))?;
+        .ok_or_else(|| parse_err("无法解析未读邮件数量", json_str))?;
     Ok(raw_data.unReadCount)
 }
 

--- a/src/wxpay/electricity/parse.rs
+++ b/src/wxpay/electricity/parse.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{MapParseErr, parse_err, parse_err_with_reason},
+    error::{MapParseErr, parse_err},
     xgxt::personal_info::Dormitory,
 };
 use serde_json::Value;
@@ -21,7 +21,7 @@ pub fn convert_dormitory(
         "德智留学生公寓" => 5,
         "望麓桥学生公寓" => 6,
         "牛头山学生公寓" => 7,
-        v => return Err(parse_err_with_reason(v, "park")),
+        _ => return Err(parse_err("未知校区", &format!("{:?}", dormitory))),
     };
     let build_id = match (park_id, build) {
         // 南校区
@@ -40,14 +40,14 @@ pub fn convert_dormitory(
             let no = room
                 .chars()
                 .next()
-                .ok_or_else(|| parse_err_with_reason(room, "room"))?;
+                .ok_or_else(|| parse_err("找不到房间号", &format!("{:?}", dormitory)))?;
             match no {
                 '1' => "25-1",
                 '2' => "25-2",
                 '3' => "25-3",
                 '4' => "25-4",
                 _ => {
-                    return Err(parse_err_with_reason(room, "room"));
+                    return Err(parse_err("未知房间号", &format!("{:?}", dormitory)));
                 }
             }
         }
@@ -117,10 +117,7 @@ pub fn convert_dormitory(
         (7, "6栋") => "64",
         (7, "7栋") => "65",
         _ => {
-            return Err(parse_err_with_reason(
-                &format!("{:?}", (park, build)),
-                "(park, build)",
-            ));
+            return Err(parse_err("未知宿舍", &format!("{:?}", (park, build))));
         }
     };
     let room_id = match (park_id, build, room) {
@@ -139,7 +136,7 @@ pub fn convert_dormitory(
         (1, "19舍", r) => {
             let parts = r.split('-').collect::<Vec<&str>>();
             if parts.len() != 2 {
-                return Err(parse_err_with_reason(r, "room"));
+                return Err(parse_err("房间号格式错误", &format!("{:?}", dormitory)));
             }
             if parts[1].starts_with('附') {
                 format!("F{}", parts[1].replace('附', ""))
@@ -159,7 +156,7 @@ pub fn electricity(json_str: &str) -> Result<String, crate::Error<Infallible>> {
         .get("data")
         .and_then(|data| data.get("Balance"))
         .and_then(|balance| balance.as_str())
-        .ok_or(parse_err(json_str))?
+        .ok_or(parse_err("解析余额失败", json_str))?
         .to_string();
     Ok(res)
 }

--- a/src/xgxt/personal_info/parse.rs
+++ b/src/xgxt/personal_info/parse.rs
@@ -1,6 +1,6 @@
 use super::dormitory::parse_dormitory;
 use super::{Gender, Level, PersonalInfo};
-use crate::error::{MapParseErr, parse_err, parse_err_with_reason};
+use crate::error::{MapParseErr, parse_err};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -18,7 +18,7 @@ pub fn extract_xgxt_entry(
         .and_then(|group_field_list| group_field_list.get(0))
         .and_then(|group_field_item| group_field_item.get("fields"))
         .and_then(|fields| fields.as_array())
-        .ok_or(parse_err(json_str))?
+        .ok_or(parse_err("无法解析学工系统个人信息", json_str))?
         .iter()
         .for_each(|field| {
             if let Some(field_name) = field.get("fieldName")
@@ -46,12 +46,12 @@ pub fn person_info(
 
     let name = entries
         .remove("姓名")
-        .ok_or(parse_err_with_reason(&entries_str, "name"))?;
+        .ok_or(parse_err("找不到姓名", &entries_str))?;
     let enter_year: u16 = entries
         .remove("年级")
-        .ok_or(parse_err_with_reason(&entries_str, "enter_year"))?
+        .ok_or(parse_err("找不到年级", &entries_str))?
         .parse()
-        .parse_err_with_reason(&entries_str, "enter_year")?;
+        .parse_err(&entries_str)?;
     let xz = entries
         .remove("学制(年)")
         .and_then(|v| {
@@ -62,44 +62,44 @@ pub fn person_info(
             }
         })
         .transpose()
-        .parse_err_with_reason(&entries_str, "xz")?;
+        .parse_err(&entries_str)?;
     let stu_id = entries
         .remove("学号")
-        .ok_or(parse_err_with_reason(&entries_str, "stu_id"))?;
+        .ok_or(parse_err("找不到学号", &entries_str))?;
     let gender = match entries.get("性别").map(|v| v.as_str()) {
         Some("1") => Gender::Male,
         Some("2") => Gender::Female,
         _ => {
-            return Err(parse_err_with_reason(&entries_str, "gender"))?;
+            return Err(parse_err("未知性别", &entries_str))?;
         }
     };
     let level = match entries
         .remove("培养层次")
-        .ok_or(parse_err_with_reason(&entries_str, "level"))?
+        .ok_or(parse_err("找不到培养层次", &entries_str))?
         .as_ref()
     {
         "1" => Level::Doctoral,
         "2" => Level::Postgraduate,
         "3" => Level::Undergraduate,
         _ => {
-            return Err(parse_err_with_reason(&entries_str, "level"))?;
+            return Err(parse_err("未知培养层次", &entries_str))?;
         }
     };
     let academy = entries
         .remove("学院")
-        .ok_or(parse_err_with_reason(&entries_str, "academy"))?;
+        .ok_or(parse_err("找不到学院", &entries_str))?;
     let major = entries
         .remove("专业")
-        .ok_or(parse_err_with_reason(&entries_str, "major"))?;
+        .ok_or(parse_err("找不到专业", &entries_str))?;
     let class = entries
         .remove("班级")
-        .ok_or(parse_err_with_reason(&entries_str, "class"))?;
+        .ok_or(parse_err("找不到班级", &entries_str))?;
     let dormitory = entries
         .remove("寝室楼")
-        .ok_or(parse_err_with_reason(&entries_str, "dormitory"))?;
+        .ok_or(parse_err("找不到寝室楼", &entries_str))?;
     let room = entries
         .remove("寝室号")
-        .ok_or(parse_err_with_reason(&entries_str, "room"))?;
+        .ok_or(parse_err("找不到寝室号", &entries_str))?;
     let dormitory = if dormitory.is_empty() || room.is_empty() {
         None
     } else {

--- a/src/yjsxt/class_table/parse.rs
+++ b/src/yjsxt/class_table/parse.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{MapParseErr, parse_err, parse_err_with_reason},
+    error::{MapParseErr, parse_err},
     yjsxt::{
         class_table::{Course, CourseSchedule},
         error::TokenExpired,
@@ -36,21 +36,21 @@ fn parse_course_info(
     // 研究生系统返回的信息可能有多余的神秘空格，要去掉
     let course_id = parts
         .first()
-        .ok_or_else(|| parse_err(cell_text))?
+        .ok_or_else(|| parse_err("找不到课程编号", cell_text))?
         .replace("课程编号:", "")
         .chars()
         .filter(|c| !c.is_whitespace())
         .collect::<String>();
     let course_name = parts
         .get(1)
-        .ok_or_else(|| parse_err(cell_text))?
+        .ok_or_else(|| parse_err("找不到课程名称", cell_text))?
         .replace("课程名称:", "")
         .chars()
         .filter(|c| !c.is_whitespace())
         .collect::<String>();
     let class_name = parts
         .get(2)
-        .ok_or_else(|| parse_err(cell_text))?
+        .ok_or_else(|| parse_err("找不到班级", cell_text))?
         .replace("班级:", "")
         .chars()
         .filter(|c| !c.is_whitespace())
@@ -59,7 +59,7 @@ fn parse_course_info(
     // 上课时间: [9-16周] 连续周
     let class_time_str = parts
         .get(3)
-        .ok_or_else(|| parse_err(cell_text))?
+        .ok_or_else(|| parse_err("找不到上课时间", cell_text))?
         .chars()
         .filter(|c| !c.is_whitespace())
         .collect::<String>();
@@ -72,16 +72,16 @@ fn parse_course_info(
                 .map(|s| s.parse::<u8>().ok())
                 .collect::<Option<Vec<_>>>()
         })
-        .ok_or_else(|| parse_err_with_reason(&class_time_str, "解析上课时间失败"))?;
+        .ok_or_else(|| parse_err("解析上课时间失败", &class_time_str))?;
     let Some(weeks_l) = class_time.first() else {
-        return Err(parse_err_with_reason(&class_time_str, "解析上课时间失败"));
+        return Err(parse_err("解析上课时间失败", &class_time_str));
     };
     // 可能只有一个周次
     let weeks_r = class_time.get(1).unwrap_or(weeks_l);
 
     let teacher_and_classroom_str = parts
         .get(4)
-        .ok_or_else(|| parse_err(cell_text))?
+        .ok_or_else(|| parse_err("找不到授课老师和上课地点", cell_text))?
         .chars()
         .filter(|c| !c.is_whitespace())
         .collect::<String>();
@@ -93,14 +93,14 @@ fn parse_course_info(
                 .collect::<Option<Vec<_>>>()
         })
     else {
-        return Err(parse_err_with_reason(
-            &teacher_and_classroom_str,
+        return Err(parse_err(
             "解析授课老师和上课地点失败",
+            &teacher_and_classroom_str,
         ));
     };
-    let [_, teacher, classroom] = teacher_and_classroom.try_into().map_err(|_| {
-        parse_err_with_reason(&teacher_and_classroom_str, "解析授课老师和上课地点失败")
-    })?;
+    let [_, teacher, classroom] = teacher_and_classroom
+        .try_into()
+        .map_err(|_| parse_err("解析授课老师和上课地点失败", &teacher_and_classroom_str))?;
 
     let res = ParsedCourse {
         course_name,
@@ -122,7 +122,7 @@ pub fn class_table(json_str: &str) -> Result<Vec<Course>, crate::Error<TokenExpi
     let raw_rows = json
         .get("rows")
         .and_then(|rows| rows.as_array())
-        .ok_or_else(|| parse_err(&json_str))?;
+        .ok_or_else(|| parse_err("无法解析课表行", &json_str))?;
 
     // 研究生系统的课表的颗粒度比我们的更细，他们把节次信息也拆掉了
     // 所以我们这里需要把同一个课程，同一周次、周几、上课地点的节次信息合并
@@ -135,7 +135,7 @@ pub fn class_table(json_str: &str) -> Result<Vec<Course>, crate::Error<TokenExpi
     for item in raw_rows {
         let jc = item["mc"]
             .as_str()
-            .ok_or_else(|| parse_err_with_reason(&item.to_string(), "解析节次失败"))?;
+            .ok_or_else(|| parse_err("解析节次失败", &item.to_string()))?;
         for day in 1..=7u8 {
             let key = format!("z{day}");
             if item[&key] == Value::Null {
@@ -144,13 +144,13 @@ pub fn class_table(json_str: &str) -> Result<Vec<Course>, crate::Error<TokenExpi
 
             let cell_text = item[&key]
                 .as_str()
-                .ok_or_else(|| parse_err(&item.to_string()))?;
+                .ok_or_else(|| parse_err("解析课表单元格文本失败", &item.to_string()))?;
             let (course_info, weeks, place) = parse_course_info(cell_text)?;
 
             if jc == "无节次" {
                 extra_courses.insert(course_info, ());
             } else {
-                let jc = jc.parse::<u8>().parse_err_with_reason(jc, "解析节次失败")?;
+                let jc = jc.parse::<u8>().parse_err(jc)?;
                 let entry = course_map.entry(course_info).or_default();
                 for week in weeks {
                     let entry = entry.entry((week, day, place.clone())).or_default();

--- a/src/yjsxt/login.rs
+++ b/src/yjsxt/login.rs
@@ -62,7 +62,7 @@ impl YjsxtToken {
             .split("/gmis/")
             .nth(1)
             .and_then(|s| s.split('/').next())
-            .ok_or_else(|| parse_err(redirection))?
+            .ok_or_else(|| parse_err("找不到研究生系统令牌 id", redirection))?
             .to_string();
         let new_url = format!("http://yjsxt.hnu.edu.cn{}", redirection);
         let res = client
@@ -80,7 +80,7 @@ impl YjsxtToken {
             if location_str.contains("/home/err") {
                 // TODO 这么解析不太好
                 let msg = location_str.split("msg=").nth(1).unwrap_or("");
-                let msg = decode(msg).parse_err_with_reason(msg, "url解码失败")?;
+                let msg = decode(msg).parse_err(msg)?;
                 return Err(msg).unexpected_err();
             }
         }

--- a/src/yjsxt/parse.rs
+++ b/src/yjsxt/parse.rs
@@ -8,14 +8,12 @@ type Aes128EcbDec = ecb::Decryptor<aes::Aes128>;
 
 // 研究生系统的响应存在加密，需要解密
 pub fn decrypt_response(data: &str) -> Result<String, crate::Error<TokenExpired>> {
-    let decode = base64
-        .decode(data)
-        .parse_err_with_reason(data, "base64 解码失败")?;
+    let decode = base64.decode(data).parse_err(data)?;
     let key = <aes::cipher::generic_array::GenericArray<u8, _>>::from_slice(
         &GRADUATE_KEY.as_bytes()[..16],
     );
     let res = Aes128EcbDec::new(key)
         .decrypt_padded_vec_mut::<Pkcs7>(&decode)
-        .parse_err_with_reason(data, "AES 解密失败")?;
-    String::from_utf8(res).parse_err_with_reason(data, "UTF-8 转换失败")
+        .parse_err(data)?;
+    String::from_utf8(res).parse_err(data)
 }

--- a/src/yjsxt/semester/parse.rs
+++ b/src/yjsxt/semester/parse.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{MapParseErr, parse_err, parse_err_with_reason},
+    error::{MapParseErr, parse_err},
     yjsxt::{error::TokenExpired, semester::Semester},
 };
 use serde::Deserialize;
@@ -19,7 +19,7 @@ pub fn semester(json_str: &str) -> Result<Vec<Semester>, crate::Error<TokenExpir
         let (xn_str, other) = raw_item
             .termname
             .split_once('-')
-            .ok_or_else(|| parse_err(&json_str))?;
+            .ok_or_else(|| parse_err("解析学期失败", &json_str))?;
         let xn = xn_str.parse::<u16>().parse_err(&json_str)?;
         let xq = if other.contains("秋学期") {
             1
@@ -28,7 +28,7 @@ pub fn semester(json_str: &str) -> Result<Vec<Semester>, crate::Error<TokenExpir
         } else if other.contains("暑假学期") {
             3
         } else {
-            return Err(parse_err_with_reason(&json_str, "未知学期"));
+            return Err(parse_err("未知学期", &json_str));
         };
         res.push(Semester {
             xn,


### PR DESCRIPTION
- ParseError 记录了产生异常的位置。去除了 `parse_err_with_reason`。
- 暴露获取产生异常位置的函数
- 将 ParseError 和 UnexpectedError 单独抽出来